### PR TITLE
Adding qemu for cross-architecture python linux builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64, x86, aarch64, armv7]
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
I was eager to try this out, but noticed that the python releases weren't lining up with rust releases due to to CI issues with the cross-architecture linux builds. Based on my read of the [maturin-action documentation](https://github.com/PyO3/maturin-action/blob/main/README.md?plain=1#L82-L102), an additional workflow step is needed so it can build for non x86_64 architectures.

Since this is a CI thing, I can't really be sure it'll work until we open a PR and run the workflow so :crossed_fingers:. That said, it appears to have [built successfully on my PR fork](https://github.com/riordan/feco3/actions/runs/5864351172?pr=1).